### PR TITLE
feat: Phase 2-3 - Lambda function for leaveGroup logic

### DIFF
--- a/lambda/domain/node.rb
+++ b/lambda/domain/node.rb
@@ -1,0 +1,20 @@
+# Node Domain Model
+# ドメインモデル - ノードのビジネスルールとバリデーションを持つ
+class Node
+  attr_reader :id, :name, :group_id, :domain
+
+  def initialize(id:, name: nil, group_id: nil, domain: nil)
+    @id = id
+    @name = name || "Node #{id}"
+    @group_id = group_id
+    @domain = domain
+
+    validate!
+  end
+
+  private
+
+  def validate!
+    raise ArgumentError, 'id is required' if @id.nil? || @id.to_s.empty?
+  end
+end

--- a/lambda/repositories/dynamodb_repository.rb
+++ b/lambda/repositories/dynamodb_repository.rb
@@ -62,6 +62,106 @@ class DynamoDBRepository
     false
   end
 
+  # グループIDとドメインでグループを検索
+  def find_group(group_id, domain)
+    return nil unless @dynamodb
+
+    result = @dynamodb.get_item(
+      table_name: @table_name,
+      key: {
+        'pk' => "DOMAIN##{domain}",
+        'sk' => "GROUP##{group_id}#METADATA"
+      }
+    )
+
+    return nil unless result.item
+
+    item_to_group(result.item)
+  rescue Aws::DynamoDB::Errors::ServiceError => e
+    puts "DynamoDB Error: #{e.message}"
+    nil
+  end
+
+  # グループ全体を削除（ホスト退出時）
+  def dissolve_group(group_id, domain)
+    return false unless @dynamodb
+
+    # 1. グループ内の全アイテムを取得
+    result = @dynamodb.query(
+      table_name: @table_name,
+      key_condition_expression: 'pk = :pk AND begins_with(sk, :sk_prefix)',
+      expression_attribute_values: {
+        ':pk' => "DOMAIN##{domain}",
+        ':sk_prefix' => "GROUP##{group_id}"
+      }
+    )
+
+    # 2. 全アイテムを削除
+    result.items.each do |item|
+      @dynamodb.delete_item(
+        table_name: @table_name,
+        key: {
+          'pk' => item['pk'],
+          'sk' => item['sk']
+        }
+      )
+    end
+
+    # 3. 各ノードの所属情報も削除
+    node_items = result.items.select { |item| item['sk'].include?('#NODE#') }
+    node_items.each do |item|
+      node_id = item['nodeId']
+      @dynamodb.delete_item(
+        table_name: @table_name,
+        key: {
+          'pk' => "NODE##{node_id}",
+          'sk' => 'METADATA'
+        }
+      )
+    end
+
+    true
+  rescue Aws::DynamoDB::Errors::ServiceError => e
+    puts "DynamoDB Error: #{e.message}"
+    false
+  end
+
+  # ノードをグループから削除（一般メンバー退出時）
+  def remove_node_from_group(group_id, domain, node_id)
+    return false unless @dynamodb
+
+    # TransactWriteItems でアトミックに削除
+    @dynamodb.transact_write_items(
+      transact_items: [
+        # 1. グループ内のノード情報を削除
+        {
+          delete: {
+            table_name: @table_name,
+            key: {
+              'pk' => "DOMAIN##{domain}",
+              'sk' => "GROUP##{group_id}#NODE##{node_id}"
+            }
+          }
+        },
+        # 2. ノードの所属情報を削除
+        {
+          delete: {
+            table_name: @table_name,
+            key: {
+              'pk' => "NODE##{node_id}",
+              'sk' => 'METADATA'
+            }
+          }
+        }
+      ]
+    )
+
+    true
+  rescue Aws::DynamoDB::Errors::ServiceError => e
+    puts "DynamoDB Error: #{e.message}"
+    false
+  end
+
   private
 
   def item_to_group(item)

--- a/lambda/use_cases/leave_group.rb
+++ b/lambda/use_cases/leave_group.rb
@@ -1,0 +1,59 @@
+require_relative '../domain/group'
+require_relative '../domain/node'
+
+# LeaveGroup Use Case
+# ビジネスロジック - グループ退出処理のフローを管理
+class LeaveGroupUseCase
+  def initialize(repository)
+    @repository = repository
+  end
+
+  def execute(group_id:, domain:, node_id:)
+    # 入力バリデーション
+    validate_input!(group_id, domain, node_id)
+
+    # グループ情報を取得
+    group = @repository.find_group(group_id, domain)
+    raise StandardError, "Group not found: #{group_id}@#{domain}" unless group
+
+    # ホスト判定
+    if group.host_id == node_id
+      # ホスト退出 → グループ解散
+      handle_host_leaving(group_id, domain)
+    else
+      # 一般メンバー退出 → メンバー削除
+      handle_member_leaving(group_id, domain, node_id)
+    end
+  end
+
+  private
+
+  def validate_input!(group_id, domain, node_id)
+    raise ArgumentError, 'group_id is required' if group_id.nil? || group_id.to_s.empty?
+    raise ArgumentError, 'domain is required' if domain.nil? || domain.to_s.empty?
+    raise ArgumentError, 'node_id is required' if node_id.nil? || node_id.to_s.empty?
+  end
+
+  def handle_host_leaving(group_id, domain)
+    # グループ全体を削除
+    success = @repository.dissolve_group(group_id, domain)
+    raise StandardError, "Failed to dissolve group: #{group_id}@#{domain}" unless success
+
+    # ホスト退出の場合はnilを返す（GraphQLではNode?型なのでnull可能）
+    nil
+  end
+
+  def handle_member_leaving(group_id, domain, node_id)
+    # メンバーをグループから削除
+    success = @repository.remove_node_from_group(group_id, domain, node_id)
+    raise StandardError, "Failed to remove node from group: #{node_id}" unless success
+
+    # 退出後のNodeオブジェクトを返す（group_idとdomainはnil）
+    Node.new(
+      id: node_id,
+      name: "Node #{node_id}",
+      group_id: nil,
+      domain: nil
+    )
+  end
+end

--- a/spec/fixtures/mutations/leave_group.graphql
+++ b/spec/fixtures/mutations/leave_group.graphql
@@ -1,0 +1,8 @@
+mutation LeaveGroup($groupId: ID!, $domain: String!, $nodeId: ID!) {
+  leaveGroup(groupId: $groupId, domain: $domain, nodeId: $nodeId) {
+    id
+    name
+    groupId
+    domain
+  }
+}

--- a/spec/requests/leave_group_spec.rb
+++ b/spec/requests/leave_group_spec.rb
@@ -1,0 +1,165 @@
+require 'spec_helper'
+
+RSpec.describe 'Leave Group API', type: :request do
+  let(:domain) { "test-leave-#{Time.now.to_i}.example.com" }
+  let(:host_id) { "host-leave-#{Time.now.to_i}" }
+  let(:member1_id) { "member1-leave-#{Time.now.to_i}" }
+  let(:member2_id) { "member2-leave-#{Time.now.to_i}" }
+
+  describe 'leaveGroup mutation' do
+    context '一般メンバーが退出する場合' do
+      it 'メンバーがグループから退出できる' do
+        # Setup: グループを作成
+        group = create_test_group('Leave Test Group', host_id, domain)
+        group_id = group['id']
+
+        # Setup: メンバー1をグループに参加させる
+        join_test_node(group_id, domain, member1_id)
+
+        # Setup: メンバー2をグループに参加させる
+        join_test_node(group_id, domain, member2_id)
+
+        # Execute: メンバー1が退出
+        query = File.read(File.join(__dir__, '../fixtures/mutations/leave_group.graphql'))
+        response = execute_graphql(query, {
+          groupId: group_id,
+          domain: domain,
+          nodeId: member1_id
+        })
+
+        # Verify: エラーがないこと
+        expect(response['errors']).to be_nil
+
+        # Verify: Nodeオブジェクトが返されること
+        node = response['data']['leaveGroup']
+        expect(node).not_to be_nil
+        expect(node['id']).to eq(member1_id)
+        expect(node['groupId']).to be_nil  # 退出後はnull
+        expect(node['domain']).to be_nil   # 退出後はnull
+
+        # Verify: グループにはメンバー2とホストのみが残っていること
+        list_query = File.read(File.join(__dir__, '../fixtures/queries/list_groups_by_domain.graphql'))
+        list_response = execute_graphql(list_query, { domain: domain })
+        groups = list_response['data']['listGroupsByDomain']
+
+        # グループがまだ存在することを確認
+        expect(groups).not_to be_empty
+        expect(groups.first['id']).to eq(group_id)
+      end
+
+      it '複数メンバーが順次退出できる' do
+        # Setup: グループを作成
+        group = create_test_group('Multi Leave Test Group', host_id, domain)
+        group_id = group['id']
+
+        # Setup: メンバー1, 2をグループに参加させる
+        join_test_node(group_id, domain, member1_id)
+        join_test_node(group_id, domain, member2_id)
+
+        # Execute: メンバー1が退出
+        query = File.read(File.join(__dir__, '../fixtures/mutations/leave_group.graphql'))
+        response1 = execute_graphql(query, {
+          groupId: group_id,
+          domain: domain,
+          nodeId: member1_id
+        })
+
+        expect(response1['errors']).to be_nil
+        expect(response1['data']['leaveGroup']['id']).to eq(member1_id)
+
+        # Execute: メンバー2が退出
+        response2 = execute_graphql(query, {
+          groupId: group_id,
+          domain: domain,
+          nodeId: member2_id
+        })
+
+        expect(response2['errors']).to be_nil
+        expect(response2['data']['leaveGroup']['id']).to eq(member2_id)
+
+        # Verify: グループにはホストのみが残っている
+        list_query = File.read(File.join(__dir__, '../fixtures/queries/list_groups_by_domain.graphql'))
+        list_response = execute_graphql(list_query, { domain: domain })
+        groups = list_response['data']['listGroupsByDomain']
+
+        expect(groups).not_to be_empty
+        expect(groups.first['id']).to eq(group_id)
+      end
+    end
+
+    context 'ホストが退出する場合（グループ解散）' do
+      it 'ホストが退出するとグループ全体が削除される' do
+        # Setup: グループを作成
+        group = create_test_group('Host Leave Test Group', host_id, domain)
+        group_id = group['id']
+
+        # Setup: メンバーをグループに参加させる
+        join_test_node(group_id, domain, member1_id)
+
+        # Execute: ホストが退出（グループ解散）
+        query = File.read(File.join(__dir__, '../fixtures/mutations/leave_group.graphql'))
+        response = execute_graphql(query, {
+          groupId: group_id,
+          domain: domain,
+          nodeId: host_id
+        })
+
+        # Verify: エラーがないこと
+        expect(response['errors']).to be_nil
+
+        # Verify: nullが返されること（ホスト退出の場合）
+        expect(response['data']['leaveGroup']).to be_nil
+
+        # Verify: グループが削除されていること
+        list_query = File.read(File.join(__dir__, '../fixtures/queries/list_groups_by_domain.graphql'))
+        list_response = execute_graphql(list_query, { domain: domain })
+        groups = list_response['data']['listGroupsByDomain']
+
+        # グループが存在しないこと
+        matching_groups = groups.select { |g| g['id'] == group_id }
+        expect(matching_groups).to be_empty
+      end
+
+      it 'ホストのみのグループでホストが退出できる' do
+        # Setup: グループを作成（メンバーなし）
+        group = create_test_group('Solo Host Leave Test', host_id, domain)
+        group_id = group['id']
+
+        # Execute: ホストが退出
+        query = File.read(File.join(__dir__, '../fixtures/mutations/leave_group.graphql'))
+        response = execute_graphql(query, {
+          groupId: group_id,
+          domain: domain,
+          nodeId: host_id
+        })
+
+        # Verify
+        expect(response['errors']).to be_nil
+        expect(response['data']['leaveGroup']).to be_nil
+
+        # Verify: グループが削除されていること
+        list_query = File.read(File.join(__dir__, '../fixtures/queries/list_groups_by_domain.graphql'))
+        list_response = execute_graphql(list_query, { domain: domain })
+        groups = list_response['data']['listGroupsByDomain']
+
+        matching_groups = groups.select { |g| g['id'] == group_id }
+        expect(matching_groups).to be_empty
+      end
+    end
+
+    context 'エラーケース' do
+      it '存在しないグループからの退出はエラーになる' do
+        query = File.read(File.join(__dir__, '../fixtures/mutations/leave_group.graphql'))
+        response = execute_graphql(query, {
+          groupId: 'non-existent-group',
+          domain: domain,
+          nodeId: member1_id
+        })
+
+        # エラーが返されること
+        expect(response['errors']).not_to be_nil
+        expect(response['errors'].first['message']).to include('Group not found')
+      end
+    end
+  end
+end

--- a/spec/unit/use_cases/leave_group_spec.rb
+++ b/spec/unit/use_cases/leave_group_spec.rb
@@ -1,0 +1,160 @@
+require 'spec_helper'
+require 'time'
+require_relative '../../../lambda/use_cases/leave_group'
+require_relative '../../../lambda/domain/group'
+require_relative '../../../lambda/domain/node'
+
+RSpec.describe LeaveGroupUseCase do
+  let(:repository) { double('Repository') }
+  let(:use_case) { described_class.new(repository) }
+
+  describe '#execute' do
+    let(:group_id) { 'group-123' }
+    let(:domain) { 'example.com' }
+    let(:host_id) { 'host-001' }
+    let(:member_id) { 'member-002' }
+
+    let(:existing_group) do
+      Group.new(
+        id: group_id,
+        name: 'Test Group',
+        host_id: host_id,
+        domain: domain,
+        created_at: Time.now.utc.iso8601
+      )
+    end
+
+    context '一般メンバーが退出する場合' do
+      it 'メンバーをグループから削除してNodeを返す' do
+        # Setup: グループ情報取得
+        allow(repository).to receive(:find_group)
+          .with(group_id, domain)
+          .and_return(existing_group)
+
+        # Setup: メンバー削除操作
+        expect(repository).to receive(:remove_node_from_group)
+          .with(group_id, domain, member_id)
+          .and_return(true)
+
+        # Execute
+        result = use_case.execute(
+          group_id: group_id,
+          domain: domain,
+          node_id: member_id
+        )
+
+        # Verify: Nodeオブジェクトが返される
+        expect(result).to be_a(Node)
+        expect(result.id).to eq(member_id)
+        expect(result.group_id).to be_nil # 退出後はグループIDがnil
+        expect(result.domain).to be_nil
+      end
+
+      it 'メンバー削除に失敗した場合はエラーを発生させる' do
+        allow(repository).to receive(:find_group)
+          .with(group_id, domain)
+          .and_return(existing_group)
+
+        allow(repository).to receive(:remove_node_from_group)
+          .with(group_id, domain, member_id)
+          .and_return(false)
+
+        expect {
+          use_case.execute(
+            group_id: group_id,
+            domain: domain,
+            node_id: member_id
+          )
+        }.to raise_error(StandardError, /Failed to remove node from group/)
+      end
+    end
+
+    context 'ホストが退出する場合（グループ解散）' do
+      it 'グループ全体を削除してnilを返す' do
+        # Setup: グループ情報取得（hostIdが一致）
+        allow(repository).to receive(:find_group)
+          .with(group_id, domain)
+          .and_return(existing_group)
+
+        # Setup: グループ解散操作
+        expect(repository).to receive(:dissolve_group)
+          .with(group_id, domain)
+          .and_return(true)
+
+        # Execute
+        result = use_case.execute(
+          group_id: group_id,
+          domain: domain,
+          node_id: host_id
+        )
+
+        # Verify: nilが返される（GraphQLスキーマではNode?型なのでnull可能）
+        expect(result).to be_nil
+      end
+
+      it 'グループ解散に失敗した場合はエラーを発生させる' do
+        allow(repository).to receive(:find_group)
+          .with(group_id, domain)
+          .and_return(existing_group)
+
+        allow(repository).to receive(:dissolve_group)
+          .with(group_id, domain)
+          .and_return(false)
+
+        expect {
+          use_case.execute(
+            group_id: group_id,
+            domain: domain,
+            node_id: host_id
+          )
+        }.to raise_error(StandardError, /Failed to dissolve group/)
+      end
+    end
+
+    context 'エラーケース' do
+      it 'グループが存在しない場合はエラーを発生させる' do
+        allow(repository).to receive(:find_group)
+          .with(group_id, domain)
+          .and_return(nil)
+
+        expect {
+          use_case.execute(
+            group_id: group_id,
+            domain: domain,
+            node_id: member_id
+          )
+        }.to raise_error(StandardError, /Group not found/)
+      end
+
+      it 'group_idが空の場合はエラーを発生させる' do
+        expect {
+          use_case.execute(
+            group_id: '',
+            domain: domain,
+            node_id: member_id
+          )
+        }.to raise_error(ArgumentError, /group_id is required/)
+      end
+
+      it 'domainが空の場合はエラーを発生させる' do
+        expect {
+          use_case.execute(
+            group_id: group_id,
+            domain: '',
+            node_id: member_id
+          )
+        }.to raise_error(ArgumentError, /domain is required/)
+      end
+
+      it 'node_idが空の場合はエラーを発生させる' do
+        expect {
+          use_case.execute(
+            group_id: group_id,
+            domain: domain,
+            node_id: ''
+          )
+        }.to raise_error(ArgumentError, /node_id is required/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements Phase 2-3 of the Mesh v2 project: Lambda function for `leaveGroup` mutation with host detection and group dissolution logic.

## Implementation Highlights

### Architecture
- **Hexagonal Architecture**: Clear separation between domain, application, infrastructure, and adapter layers
- **TDD Approach**: RED → GREEN → REFACTOR cycle with comprehensive test coverage

### Key Features

#### Host Detection Logic
```ruby
if group.host_id == node_id
  # Host leaving → dissolve entire group
  dissolve_group(group_id, domain)
  return nil
else
  # Regular member leaving → remove from group
  remove_node_from_group(group_id, domain, node_id)
  return Node
end
```

#### DynamoDB Operations
- **find_group**: Single GetItem for group metadata
- **remove_node_from_group**: Atomic deletion using TransactWriteItems (2 items)
- **dissolve_group**: Query + delete all group items + node metadata cleanup

### Lambda Function
- **Runtime**: Ruby 3.2
- **Handler**: `handlers/appsync_handler.lambda_handler`
- **Timeout**: 30 seconds
- **Permissions**: DynamoDB read/write access

## Test Results

### Unit Tests (8/8 ✅)
```
LeaveGroupUseCase
  #execute
    一般メンバーが退出する場合
      ✓ メンバーをグループから削除してNodeを返す
      ✓ メンバー削除に失敗した場合はエラーを発生させる
    ホストが退出する場合（グループ解散）
      ✓ グループ全体を削除してnilを返す
      ✓ グループ解散に失敗した場合はエラーを発生させる
    エラーケース
      ✓ グループが存在しない場合はエラーを発生させる
      ✓ group_idが空の場合はエラーを発生させる
      ✓ domainが空の場合はエラーを発生させる
      ✓ node_idが空の場合はエラーを発生させる
```

### Integration Tests (5/5 ✅)
```
Leave Group API
  leaveGroup mutation
    一般メンバーが退出する場合
      ✓ メンバーがグループから退出できる
      ✓ 複数メンバーが順次退出できる
    ホストが退出する場合（グループ解散）
      ✓ ホストが退出するとグループ全体が削除される
      ✓ ホストのみのグループでホストが退出できる
    エラーケース
      ✓ 存在しないグループからの退出はエラーになる
```

## Deployment

Deployed to staging environment:
- **Stack**: MeshV2Stack-stg
- **Lambda**: MeshV2-LeaveGroup-stg
- **GraphQL API**: https://rb6mjlr72rhudiztdmfvoyctbq.appsync-api.ap-northeast-1.amazonaws.com/graphql

## Files Changed

### Created (5 files)
- `lambda/domain/node.rb` - Node domain model
- `lambda/use_cases/leave_group.rb` - LeaveGroup use case
- `spec/unit/use_cases/leave_group_spec.rb` - Unit tests
- `spec/requests/leave_group_spec.rb` - Integration tests
- `spec/fixtures/mutations/leave_group.graphql` - GraphQL mutation fixture

### Modified (3 files)
- `lambda/repositories/dynamodb_repository.rb` - Added 3 repository methods
- `lambda/handlers/appsync_handler.rb` - Added leaveGroup handler
- `lib/mesh-v2-stack.ts` - Added Lambda function and resolver

## Related Issues

- Closes #451 (Phase 2-3: Lambda関数の実装)
- Part of #444 (EPIC: Mesh v2 拡張機能の実装)

## Next Steps

- Phase 2-4: Subscription implementation (#452)
- Phase 3: Frontend Mesh v2 extension blocks (#453)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>