### PR TITLE
fix: validate group expiration in joinGroup mutation (#25)

### DIFF
--- a/js/functions/joinGroupFunction.js
+++ b/js/functions/joinGroupFunction.js
@@ -1,5 +1,6 @@
-// joinGroup Mutation Resolver
+// joinGroup Function
 // ノードをグループに参加させる（TransactWriteItemsでアトミック実行）
+// checkGroupExists Pipeline Function の後に実行されることを想定
 
 import { util } from '@aws-appsync/utils';
 
@@ -15,18 +16,6 @@ export function request(ctx) {
   return {
     operation: 'TransactWriteItems',
     transactItems: [
-      // 0. グループの存在確認 (ConditionCheck)
-      {
-        table: ctx.env.TABLE_NAME,
-        operation: 'ConditionCheck',
-        key: util.dynamodb.toMapValues({
-          pk: `DOMAIN#${domain}`,
-          sk: `GROUP#${groupId}#METADATA`
-        }),
-        condition: {
-          expression: 'attribute_exists(pk)'
-        }
-      },
       // 1. グループ内のノード情報を追加
       {
         table: ctx.env.TABLE_NAME,

--- a/spec/requests/group_existence_validation_spec.rb
+++ b/spec/requests/group_existence_validation_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe "Group Existence Validation", type: :request do
         })
 
         # エラーレスポンス検証
-        # joinGroup uses ConditionCheck which returns DynamoDB error message
+        # Pipeline resolver with checkGroupExists returns custom error message
         expect(response["errors"]).not_to be_nil
-        expect(response["errors"][0]["message"]).to include("ConditionalCheckFailed")
+        expect(response["errors"][0]["message"]).to include("not found")
+        expect(response["errors"][0]["errorType"]).to eq("GroupNotFound")
       end
     end
 
@@ -47,9 +48,9 @@ RSpec.describe "Group Existence Validation", type: :request do
         })
 
         # エラーレスポンス検証
-        # ConditionCheck failed returns DynamoDB error message
         expect(join_response["errors"]).not_to be_nil
-        expect(join_response["errors"][0]["message"]).to include("ConditionalCheckFailed")
+        expect(join_response["errors"][0]["message"]).to include("not found")
+        expect(join_response["errors"][0]["errorType"]).to eq("GroupNotFound")
       end
     end
   end
@@ -138,7 +139,8 @@ RSpec.describe "Group Existence Validation", type: :request do
         nodeId: new_node_id
       })
       expect(join_response["errors"]).not_to be_nil
-      expect(join_response["errors"][0]["message"]).to include("ConditionalCheckFailed")
+      expect(join_response["errors"][0]["message"]).to include("not found")
+      expect(join_response["errors"][0]["errorType"]).to eq("GroupNotFound")
 
       # データ報告を試みる（エラーになるべき）
       report_query = File.read(File.join(__dir__, "../fixtures/mutations/report_data_by_node.graphql"))

--- a/spec/requests/join_group_expiration_spec.rb
+++ b/spec/requests/join_group_expiration_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.describe "joinGroup expiration validation", type: :request do
+  let(:domain) { "test-join-expiration-#{Time.now.to_i}.example.com" }
+  let(:host_id) { "host-#{Time.now.to_i}" }
+  let(:node_id) { "node-#{Time.now.to_i}" }
+  let(:group_name) { "Expired Group Test" }
+
+  context "期限切れグループへの参加" do
+    it "エラーを返す" do
+      # 1. 有効期限の短いグループを作成 (1秒)
+      group = create_test_group(group_name, host_id, domain, max_connection_time_seconds: 1)
+      group_id = group["id"]
+      expect(group_id).not_to be_nil
+
+      # 有効期限を待つ (2秒)
+      sleep 2
+
+      # 2. 期限切れグループへの参加を試みる
+      join_query = File.read(File.join(__dir__, "../fixtures/mutations/join_group.graphql"))
+      join_response = execute_graphql(join_query, {
+        groupId: group_id,
+        domain: domain,
+        nodeId: node_id
+      })
+
+      # 3. エラーレスポンス検証
+      expect(join_response["errors"]).not_to be_nil
+      expect(join_response["errors"][0]["message"]).to include("Group expired")
+      expect(join_response["errors"][0]["errorType"]).to eq("GroupNotFound")
+    end
+  end
+end


### PR DESCRIPTION
This PR converts joinGroup to a pipeline resolver using checkGroupExists to ensure that users cannot join expired groups.

Changes:
- Moved joinGroup logic to a separate function.
- Updated CDK stack to use pipeline resolver for joinGroup.
- Added integration test to verify expiration validation.
- Updated existing tests to match the new error response format (GroupNotFound).