### PR TITLE
feat: AppSyncのCloudWatch Logsのコストを削減する

### DIFF
--- a/lib/mesh-v2-stack.ts
+++ b/lib/mesh-v2-stack.ts
@@ -127,10 +127,10 @@ export class MeshV2Stack extends cdk.Stack {
         MESH_POLLING_INTERVAL_SECONDS: process.env.MESH_POLLING_INTERVAL_SECONDS || '2',
       },
 
-      xrayEnabled: true,
+      xrayEnabled: stage !== 'prod',
       logConfig: {
-        fieldLogLevel: appsync.FieldLogLevel.ALL,
-        excludeVerboseContent: false,
+        fieldLogLevel: stage === 'prod' ? appsync.FieldLogLevel.ERROR : appsync.FieldLogLevel.ALL,
+        excludeVerboseContent: stage === 'prod',
       },
     });
 


### PR DESCRIPTION
## 概要
AppSyncのCloudWatch LogsおよびX-Rayのコストを削減するため、production環境でのログ出力を最小限に設定しました。

## 変更内容
- `lib/mesh-v2-stack.ts`:
    - production環境 (`stage === 'prod'`) の場合:
        - `xrayEnabled`: `false`
        - `fieldLogLevel`: `ERROR`
        - `excludeVerboseContent`: `true`
    - それ以外の環境の場合:
        - 従来通り (`xrayEnabled: true`, `fieldLogLevel: ALL`, `excludeVerboseContent: false`)

## 確認事項
- [x] `npm run build` が通ること
- [x] `npm test` が通ること
- [x] `npx cdk deploy --context stage=stg` でstaging環境にデプロイし、設定が維持されていることを確認（手動確認）
